### PR TITLE
Removing onehot_to_bit 

### DIFF
--- a/RTL/icache_bank_mp_128.sv
+++ b/RTL/icache_bank_mp_128.sv
@@ -603,8 +603,8 @@ end
 
    end
 
-   // Logic to generate the binary representation of one hot signals
-   onehot_to_bin #( .ONEHOT_WIDTH(NB_WAYS) ) WAY_MATCH_BIN (.onehot(way_match), .bin(way_match_bin[ $clog2(NB_WAYS)-1:0]) );
+   // Logic to generate the binary representation for way_match_bin
+   assign way_match_bin[$clog2(NB_WAYS)-1:0] = HIT_WAY;
    assign way_match_bin[NB_WAYS-1:$clog2(NB_WAYS)] = 0;
 
 endmodule // icache_top


### PR DESCRIPTION
The signal `way_match_bin` does not go anywhere. Anyway, the `onehot_to_bit` causes the simulation to stop when there are multiple hit-matching `TAG_read_rdata_int` with the same value, while the RTL simply uses the first available.  Or was this check put on purpose?  